### PR TITLE
Allow sending notification payload in rest-client

### DIFF
--- a/client-libraries/java/rest-client/src/com/google/android/gcm/server/Constants.java
+++ b/client-libraries/java/rest-client/src/com/google/android/gcm/server/Constants.java
@@ -172,6 +172,71 @@ public final class Constants {
   public static final String JSON_PAYLOAD = "data";
 
   /**
+   * JSON-only field representing the notification payload.
+   */
+  public static final String JSON_NOTIFICATION = "notification";
+
+  /**
+   * JSON-only field representing the notification title.
+   */
+  public static final String JSON_NOTIFICATION_TITLE = "title";
+
+  /**
+   * JSON-only field representing the notification body.
+   */
+  public static final String JSON_NOTIFICATION_BODY = "body";
+
+  /**
+   * JSON-only field representing the notification icon.
+   */
+  public static final String JSON_NOTIFICATION_ICON = "icon";
+
+  /**
+   * JSON-only field representing the notification sound.
+   */
+  public static final String JSON_NOTIFICATION_SOUND = "sound";
+
+  /**
+   * JSON-only field representing the notification badge.
+   */
+  public static final String JSON_NOTIFICATION_BADGE = "badge";
+
+  /**
+   * JSON-only field representing the notification tag.
+   */
+  public static final String JSON_NOTIFICATION_TAG = "tag";
+
+  /**
+   * JSON-only field representing the notification color.
+   */
+  public static final String JSON_NOTIFICATION_COLOR = "color";
+
+  /**
+   * JSON-only field representing the notification click action.
+   */
+  public static final String JSON_NOTIFICATION_CLICK_ACTION = "click_action";
+
+  /**
+   * JSON-only field representing the notification body localization key.
+   */
+  public static final String JSON_NOTIFICATION_BODY_LOC_KEY = "body_loc_key";
+
+  /**
+   * JSON-only field representing the notification body localization values.
+   */
+  public static final String JSON_NOTIFICATION_BODY_LOC_ARGS = "body_loc_args";
+
+  /**
+   * JSON-only field representing the notification title localization key.
+   */
+  public static final String JSON_NOTIFICATION_TITLE_LOC_KEY = "title_loc_key";
+
+  /**
+   * JSON-only field representing the notification title localization values.
+   */
+  public static final String JSON_NOTIFICATION_TITLE_LOC_ARGS = "title_loc_args";
+
+  /**
    * JSON-only field representing the number of successful messages.
    */
   public static final String JSON_SUCCESS = "success";

--- a/client-libraries/java/rest-client/src/com/google/android/gcm/server/Message.java
+++ b/client-libraries/java/rest-client/src/com/google/android/gcm/server/Message.java
@@ -66,6 +66,7 @@ public final class Message implements Serializable {
   private final Boolean dryRun;
   private final String restrictedPackageName;
   private final String priority;
+  private final Notification notification;
 
   public enum Priority {
     NORMAL, HIGH
@@ -82,6 +83,7 @@ public final class Message implements Serializable {
     private Boolean dryRun;
     private String restrictedPackageName;
     private String priority;
+    private Notification notification;
 
     public Builder() {
       this.data = new LinkedHashMap<String, String>();
@@ -150,6 +152,14 @@ public final class Message implements Serializable {
       return this;
     }
 
+    /**
+     * Sets the notification property.
+     */
+    public Builder notification(Notification value) {
+      notification = value;
+      return this;
+    }
+
     public Message build() {
       return new Message(this);
     }
@@ -164,6 +174,7 @@ public final class Message implements Serializable {
     dryRun = builder.dryRun;
     restrictedPackageName = builder.restrictedPackageName;
     priority = builder.priority;
+    notification = builder.notification;
   }
 
   /**
@@ -215,6 +226,13 @@ public final class Message implements Serializable {
     return data;
   }
 
+  /**
+   * Gets notification payload, which is immutable.
+   */
+  public Notification getNotification() {
+    return notification;
+  }
+
   @Override
   public String toString() {
     StringBuilder builder = new StringBuilder("Message(");
@@ -235,6 +253,9 @@ public final class Message implements Serializable {
     }
     if (restrictedPackageName != null) {
       builder.append("restrictedPackageName=").append(restrictedPackageName).append(", ");
+    }
+    if (notification != null) {
+      builder.append("notification: ").append(notification).append(", ");
     }
     if (!data.isEmpty()) {
       builder.append("data: {");

--- a/client-libraries/java/rest-client/src/com/google/android/gcm/server/Notification.java
+++ b/client-libraries/java/rest-client/src/com/google/android/gcm/server/Notification.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.gcm.server;
+
+import java.io.Serializable;
+import java.util.*;
+
+/**
+ * GCM message notification part.
+ *
+ * <p>
+ * Instances of this class are immutable and should be created using a
+ * {@link Builder}. Examples:
+ *
+ * <strong>Simplest notification:</strong>
+ * <pre><code>
+ * Notification notification = new Notification.Builder("myicon").build();
+ * </pre></code>
+ *
+ * <strong>Notification with optional attributes:</strong>
+ * <pre><code>
+ * Notification notification = new Notification.Builder("myicon")
+ *    .title("Hello world!")
+ *    .body("Here is a more detailed description")
+ *    .build();
+ * </pre></code>
+ */
+public final class Notification implements Serializable {
+
+  private final String title;
+  private final String body;
+  private final String icon;
+  private final String sound;
+  private final Integer badge;
+  private final String tag;
+  private final String color;
+  private final String clickAction;
+  private final String bodyLocKey;
+  private final List<String> bodyLocArgs;
+  private final String titleLocKey;
+  private final List<String> titleLocArgs;
+
+  public static final class Builder {
+
+    // required parameters
+    private final String icon;
+
+    // optional parameters
+    private String title;
+    private String body;
+    private String sound;
+    private Integer badge;
+    private String tag;
+    private String color;
+    private String clickAction;
+    private String bodyLocKey;
+    private List<String> bodyLocArgs;
+    private String titleLocKey;
+    private List<String> titleLocArgs;
+
+    public Builder(String icon) {
+      this.icon = icon;
+      this.sound = "default"; // the only currently supported value
+    }
+
+    /**
+     * Sets the title property.
+     */
+    public Builder title(String value) {
+      title = value;
+      return this;
+    }
+
+    /**
+     * Sets the body property.
+     */
+    public Builder body(String value) {
+      body = value;
+      return this;
+    }
+
+    /**
+     * Sets the sound property (default value is {@literal default}).
+     */
+    public Builder sound(String value) {
+      sound = value;
+      return this;
+    }
+
+    /**
+     * Sets the badge property.
+     */
+    public Builder badge(int value) {
+      badge = value;
+      return this;
+    }
+
+    /**
+     * Sets the tag property.
+     */
+    public Builder tag(String value) {
+      tag = value;
+      return this;
+    }
+
+    /**
+     * Sets the color property in {@literal #rrggbb} format.
+     */
+    public Builder color(String value) {
+      color = value;
+      return this;
+    }
+
+    /**
+     * Sets the click action property.
+     */
+    public Builder clickAction(String value) {
+      clickAction = value;
+      return this;
+    }
+
+    /**
+     * Sets the body localization key property.
+     */
+    public Builder bodyLocKey(String value) {
+      bodyLocKey = value;
+      return this;
+    }
+
+    /**
+     * Sets the body localization values property.
+     */
+    public Builder bodyLocArgs(List<String> value) {
+      bodyLocArgs = Collections.unmodifiableList(value);
+      return this;
+    }
+
+    /**
+     * Sets the title localization key property.
+     */
+    public Builder titleLocKey(String value) {
+      titleLocKey = value;
+      return this;
+    }
+
+    /**
+     * Sets the title localization values property.
+     */
+    public Builder titleLocArgs(List<String> value) {
+      titleLocArgs = Collections.unmodifiableList(value);
+      return this;
+    }
+
+    public Notification build() {
+      return new Notification(this);
+    }
+
+  }
+
+  private Notification(Builder builder) {
+    title = builder.title;
+    body = builder.body;
+    icon = builder.icon;
+    sound = builder.sound;
+    badge = builder.badge;
+    tag = builder.tag;
+    color = builder.color;
+    clickAction = builder.clickAction;
+    bodyLocKey = builder.bodyLocKey;
+    bodyLocArgs = builder.bodyLocArgs;
+    titleLocKey = builder.titleLocKey;
+    titleLocArgs = builder.titleLocArgs;
+  }
+
+  /**
+   * Gets the title.
+   */
+  public String getTitle() {
+    return title;
+  }
+
+  /**
+   * Gets the body.
+   */
+  public String getBody() {
+    return body;
+  }
+
+  /**
+   * Gets the icon.
+   */
+  public String getIcon() {
+    return icon;
+  }
+
+  /**
+   * Gets the sound.
+   */
+  public String getSound() {
+    return sound;
+  }
+
+  /**
+   * Gets the badge.
+   */
+  public Integer getBadge() {
+    return badge;
+  }
+
+  /**
+   * Gets the tag.
+   */
+  public String getTag() {
+    return tag;
+  }
+
+  /**
+   * Gets the color.
+   */
+  public String getColor() {
+    return color;
+  }
+
+  /**
+   * Gets the click action.
+   */
+  public String getClickAction() {
+    return clickAction;
+  }
+
+  /**
+   * Gets the body localization key.
+   */
+  public String getBodyLocKey() {
+    return bodyLocKey;
+  }
+
+  /**
+   * Gets the body localization values list, which is immutable.
+   */
+  public List<String> getBodyLocArgs() {
+    return bodyLocArgs;
+  }
+
+  /**
+   * Gets the title localization key.
+   */
+  public String getTitleLocKey() {
+    return titleLocKey;
+  }
+
+  /**
+   * Gets the title localization values list, which is immutable.
+   */
+  public List<String> getTitleLocArgs() {
+    return titleLocArgs;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder("Notification(");
+    if (title != null) {
+      builder.append("title=").append(title).append(", ");
+    }
+    if (body != null) {
+      builder.append("body=").append(body).append(", ");
+    }
+    if (icon != null) {
+      builder.append("icon=").append(icon).append(", ");
+    }
+    if (sound != null) {
+      builder.append("sound=").append(sound).append(", ");
+    }
+    if (badge != null) {
+      builder.append("badge=").append(badge).append(", ");
+    }
+    if (tag != null) {
+      builder.append("tag=").append(tag).append(", ");
+    }
+    if (color != null) {
+      builder.append("color=").append(color).append(", ");
+    }
+    if (clickAction != null) {
+      builder.append("clickAction=").append(clickAction).append(", ");
+    }
+    if (bodyLocKey != null) {
+      builder.append("bodyLocKey=").append(bodyLocKey).append(", ");
+    }
+    if (bodyLocArgs != null) {
+      builder.append("bodyLocArgs=").append(bodyLocArgs).append(", ");
+    }
+    if (titleLocKey != null) {
+      builder.append("titleLocKey=").append(titleLocKey).append(", ");
+    }
+    if (titleLocArgs != null) {
+      builder.append("titleLocArgs=").append(titleLocArgs).append(", ");
+    }
+    if (builder.charAt(builder.length() - 1) == ' ') {
+      builder.delete(builder.length() - 2, builder.length());
+    }
+    builder.append(")");
+    return builder.toString();
+  }
+
+}

--- a/client-libraries/java/rest-client/src/com/google/android/gcm/server/Sender.java
+++ b/client-libraries/java/rest-client/src/com/google/android/gcm/server/Sender.java
@@ -28,16 +28,10 @@ import static com.google.android.gcm.server.Constants.JSON_SUCCESS;
 import static com.google.android.gcm.server.Constants.PARAM_COLLAPSE_KEY;
 import static com.google.android.gcm.server.Constants.PARAM_DELAY_WHILE_IDLE;
 import static com.google.android.gcm.server.Constants.PARAM_DRY_RUN;
-import static com.google.android.gcm.server.Constants.PARAM_PAYLOAD_PREFIX;
 import static com.google.android.gcm.server.Constants.PARAM_PRIORITY;
-import static com.google.android.gcm.server.Constants.PARAM_REGISTRATION_ID;
 import static com.google.android.gcm.server.Constants.PARAM_RESTRICTED_PACKAGE_NAME;
 import static com.google.android.gcm.server.Constants.PARAM_TIME_TO_LIVE;
 import static com.google.android.gcm.server.Constants.TOKEN_CANONICAL_REG_ID;
-import static com.google.android.gcm.server.Constants.TOKEN_ERROR;
-import static com.google.android.gcm.server.Constants.TOKEN_MESSAGE_ID;
-
-import com.google.android.gcm.server.Result.Builder;
 
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
@@ -52,13 +46,12 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Random;
+import java.util.Collections;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -114,7 +107,7 @@ public class Sender {
   public Result send(Message message, String registrationId, int retries)
       throws IOException {
     int attempt = 0;
-    Result result = null;
+    Result result;
     int backoff = BACKOFF_INITIAL_DELAY;
     boolean tryAgain;
     do {
@@ -147,114 +140,24 @@ public class Sender {
    * @return result of the post, or {@literal null} if the GCM service was
    *         unavailable or any network exception caused the request to fail.
    *
-   * @throws InvalidRequestException if GCM didn't returned a 200 or 5xx status.
+   * @throws InvalidRequestException if GCM didn't returned a 200 status.
    * @throws IllegalArgumentException if registrationId is {@literal null}.
    */
   public Result sendNoRetry(Message message, String registrationId)
       throws IOException {
-    StringBuilder body = newBody(PARAM_REGISTRATION_ID, registrationId);
-    String priority = message.getPriority();
-    if (priority != null) {
-      addParameter(body, PARAM_PRIORITY, priority);
-    }
-    Boolean delayWhileIdle = message.isDelayWhileIdle();
-    if (delayWhileIdle != null) {
-      addParameter(body, PARAM_DELAY_WHILE_IDLE, delayWhileIdle ? "1" : "0");
-    }
-    Boolean dryRun = message.isDryRun();
-    if (dryRun != null) {
-      addParameter(body, PARAM_DRY_RUN, dryRun ? "1" : "0");
-    }
-    String collapseKey = message.getCollapseKey();
-    if (collapseKey != null) {
-      addParameter(body, PARAM_COLLAPSE_KEY, collapseKey);
-    }
-    String restrictedPackageName = message.getRestrictedPackageName();
-    if (restrictedPackageName != null) {
-      addParameter(body, PARAM_RESTRICTED_PACKAGE_NAME, restrictedPackageName);
-    }
-    Integer timeToLive = message.getTimeToLive();
-    if (timeToLive != null) {
-      addParameter(body, PARAM_TIME_TO_LIVE, Integer.toString(timeToLive));
-    }
-    for (Entry<String, String> entry : message.getData().entrySet()) {
-      String key = entry.getKey();
-      String value = entry.getValue();
-      if (key == null || value == null) {
-        logger.warning("Ignoring payload entry thas has null: " + entry);
-      } else {
-        key = PARAM_PAYLOAD_PREFIX + key;
-        addParameter(body, key, URLEncoder.encode(value, UTF8));
-      }
-    }
-    String requestBody = body.toString();
-    logger.finest("Request body: " + requestBody);
-    HttpURLConnection conn;
-    int status;
-    try {
-      conn = post(GCM_SEND_ENDPOINT, requestBody);
-      status = conn.getResponseCode();
-    } catch (IOException e) {
-      logger.log(Level.FINE, "IOException posting to GCM", e);
+    nonNull(registrationId);
+    List<String> registrationIds = Collections.singletonList(registrationId);
+    MulticastResult multicastResult = sendNoRetry(message, registrationIds);
+    if (multicastResult == null) {
       return null;
     }
-    if (status / 100 == 5) {
-      logger.fine("GCM service is unavailable (status " + status + ")");
+    List<Result> results = multicastResult.getResults();
+    if (results.size() != 1) {
+      logger.log(Level.WARNING, "Found " + results.size() +
+          " results in single multicast request, expected one");
       return null;
     }
-    String responseBody;
-    if (status != 200) {
-      try {
-        responseBody = getAndClose(conn.getErrorStream());
-        logger.finest("Plain post error response: " + responseBody);
-      } catch (IOException e) {
-        // ignore the exception since it will thrown an InvalidRequestException
-        // anyways
-        responseBody = "N/A";
-        logger.log(Level.FINE, "Exception reading response: ", e);
-      }
-      throw new InvalidRequestException(status, responseBody);
-    } else {
-      try {
-        responseBody = getAndClose(conn.getInputStream());
-      } catch (IOException e) {
-        logger.log(Level.WARNING, "Exception reading response: ", e);
-        // return null so it can retry
-        return null;
-      }
-    }
-    String[] lines = responseBody.split("\n");
-    if (lines.length == 0 || lines[0].equals("")) {
-      throw new IOException("Received empty response from GCM service.");
-    }
-    String firstLine = lines[0];
-    String[] responseParts = split(firstLine);
-    String token = responseParts[0];
-    String value = responseParts[1];
-    if (token.equals(TOKEN_MESSAGE_ID)) {
-      Builder builder = new Result.Builder().messageId(value);
-      // check for canonical registration id
-      if (lines.length > 1) {
-        String secondLine = lines[1];
-        responseParts = split(secondLine);
-        token = responseParts[0];
-        value = responseParts[1];
-        if (token.equals(TOKEN_CANONICAL_REG_ID)) {
-          builder.canonicalRegistrationId(value);
-        } else {
-          logger.warning("Invalid response from GCM: " + responseBody);
-        }
-      }
-      Result result = builder.build();
-      if (logger.isLoggable(Level.FINE)) {
-        logger.fine("Message created succesfully (" + result + ")");
-      }
-      return result;
-    } else if (token.equals(TOKEN_ERROR)) {
-      return new Result.Builder().errorCode(value).build();
-    } else {
-      throw new IOException("Invalid response from GCM: " + responseBody);
-    }
+    return results.get(0);
   }
 
   /**
@@ -468,8 +371,7 @@ public class Sender {
           builder.addResult(result);
         }
       }
-      MulticastResult multicastResult = builder.build();
-      return multicastResult;
+      return builder.build();
     } catch (ParseException e) {
       throw newIoException(responseBody, e);
     } catch (CustomParserException e) {
@@ -524,14 +426,6 @@ public class Sender {
     }
   }
 
-  private String[] split(String line) throws IOException {
-    String[] split = line.split("=", 2);
-    if (split.length != 2) {
-      throw new IOException("Received invalid response line from GCM: " + line);
-    }
-    return split;
-  }
-
   /**
    * Make an HTTP post to a given URL.
    *
@@ -559,7 +453,7 @@ public class Sender {
    */
   protected HttpURLConnection post(String url, String contentType, String body)
       throws IOException {
-    if (url == null || body == null) {
+    if (url == null || contentType == null || body == null) {
       throw new IllegalArgumentException("arguments cannot be null");
     }
     if (!url.startsWith("https://")) {
@@ -622,8 +516,7 @@ public class Sender {
    * Gets an {@link HttpURLConnection} given an URL.
    */
   protected HttpURLConnection getConnection(String url) throws IOException {
-    HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
-    return conn;
+    return (HttpURLConnection) new URL(url).openConnection();
   }
 
   /**

--- a/client-libraries/java/rest-client/src/com/google/android/gcm/server/Sender.java
+++ b/client-libraries/java/rest-client/src/com/google/android/gcm/server/Sender.java
@@ -21,6 +21,19 @@ import static com.google.android.gcm.server.Constants.JSON_ERROR;
 import static com.google.android.gcm.server.Constants.JSON_FAILURE;
 import static com.google.android.gcm.server.Constants.JSON_MESSAGE_ID;
 import static com.google.android.gcm.server.Constants.JSON_MULTICAST_ID;
+import static com.google.android.gcm.server.Constants.JSON_NOTIFICATION_BADGE;
+import static com.google.android.gcm.server.Constants.JSON_NOTIFICATION;
+import static com.google.android.gcm.server.Constants.JSON_NOTIFICATION_BODY;
+import static com.google.android.gcm.server.Constants.JSON_NOTIFICATION_BODY_LOC_ARGS;
+import static com.google.android.gcm.server.Constants.JSON_NOTIFICATION_BODY_LOC_KEY;
+import static com.google.android.gcm.server.Constants.JSON_NOTIFICATION_CLICK_ACTION;
+import static com.google.android.gcm.server.Constants.JSON_NOTIFICATION_COLOR;
+import static com.google.android.gcm.server.Constants.JSON_NOTIFICATION_ICON;
+import static com.google.android.gcm.server.Constants.JSON_NOTIFICATION_SOUND;
+import static com.google.android.gcm.server.Constants.JSON_NOTIFICATION_TAG;
+import static com.google.android.gcm.server.Constants.JSON_NOTIFICATION_TITLE;
+import static com.google.android.gcm.server.Constants.JSON_NOTIFICATION_TITLE_LOC_ARGS;
+import static com.google.android.gcm.server.Constants.JSON_NOTIFICATION_TITLE_LOC_KEY;
 import static com.google.android.gcm.server.Constants.JSON_PAYLOAD;
 import static com.google.android.gcm.server.Constants.JSON_REGISTRATION_IDS;
 import static com.google.android.gcm.server.Constants.JSON_RESULTS;
@@ -305,13 +318,31 @@ public class Sender {
     setJsonField(jsonRequest, PARAM_TIME_TO_LIVE, message.getTimeToLive());
     setJsonField(jsonRequest, PARAM_COLLAPSE_KEY, message.getCollapseKey());
     setJsonField(jsonRequest, PARAM_RESTRICTED_PACKAGE_NAME, message.getRestrictedPackageName());
-    setJsonField(jsonRequest, PARAM_DELAY_WHILE_IDLE,
-        message.isDelayWhileIdle());
+    setJsonField(jsonRequest, PARAM_DELAY_WHILE_IDLE, message.isDelayWhileIdle());
     setJsonField(jsonRequest, PARAM_DRY_RUN, message.isDryRun());
     jsonRequest.put(JSON_REGISTRATION_IDS, registrationIds);
     Map<String, String> payload = message.getData();
     if (!payload.isEmpty()) {
       jsonRequest.put(JSON_PAYLOAD, payload);
+    }
+    if (message.getNotification() != null) {
+      Notification notification = message.getNotification();
+      Map<Object, Object> nMap = new HashMap<Object, Object>();
+      if (notification.getBadge() != null) {
+        setJsonField(nMap, JSON_NOTIFICATION_BADGE, notification.getBadge().toString());
+      }
+      setJsonField(nMap, JSON_NOTIFICATION_BODY, notification.getBody());
+      setJsonField(nMap, JSON_NOTIFICATION_BODY_LOC_ARGS, notification.getBodyLocArgs());
+      setJsonField(nMap, JSON_NOTIFICATION_BODY_LOC_KEY, notification.getBodyLocKey());
+      setJsonField(nMap, JSON_NOTIFICATION_CLICK_ACTION, notification.getClickAction());
+      setJsonField(nMap, JSON_NOTIFICATION_COLOR, notification.getColor());
+      setJsonField(nMap, JSON_NOTIFICATION_ICON, notification.getIcon());
+      setJsonField(nMap, JSON_NOTIFICATION_SOUND, notification.getSound());
+      setJsonField(nMap, JSON_NOTIFICATION_TAG, notification.getTag());
+      setJsonField(nMap, JSON_NOTIFICATION_TITLE, notification.getTitle());
+      setJsonField(nMap, JSON_NOTIFICATION_TITLE_LOC_ARGS, notification.getTitleLocArgs());
+      setJsonField(nMap, JSON_NOTIFICATION_TITLE_LOC_KEY, notification.getTitleLocKey());
+      jsonRequest.put(JSON_NOTIFICATION, nMap);
     }
     String requestBody = JSONValue.toJSONString(jsonRequest);
     logger.finest("JSON request: " + requestBody);

--- a/client-libraries/java/rest-client/test/com/google/android/gcm/server/MessageTest.java
+++ b/client-libraries/java/rest-client/test/com/google/android/gcm/server/MessageTest.java
@@ -36,6 +36,7 @@ public class MessageTest {
     assertNull(message.isDelayWhileIdle());
     assertTrue(message.getData().isEmpty());
     assertNull(message.getTimeToLive());
+    assertNull(message.getNotification());
     String toString = message.toString();
     assertFalse(toString.contains("collapseKey"));
     assertFalse(toString.contains("timeToLive"));
@@ -55,6 +56,7 @@ public class MessageTest {
         .addData("k1", "old value")
         .addData("k1", "v1")
         .addData("k2", "v2")
+        .notification(new Notification.Builder("my").build())
         .build();
     assertEquals("high", message.getPriority());
     assertEquals("108", message.getCollapseKey());
@@ -75,6 +77,7 @@ public class MessageTest {
     assertTrue(toString.contains("k2=v2"));
     assertTrue(toString.contains("dryRun=true"));
     assertTrue(toString.contains("restrictedPackageName=package.name"));
+    assertTrue(toString.contains("notification: "));
   }
 
   @Test(expected = UnsupportedOperationException.class)

--- a/client-libraries/java/rest-client/test/com/google/android/gcm/server/NotificationTest.java
+++ b/client-libraries/java/rest-client/test/com/google/android/gcm/server/NotificationTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2012 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.gcm.server;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NotificationTest {
+
+  @Test
+  public void testRequiredParameters() {
+    Notification notification = new Notification.Builder("myicon").build();
+    assertNull(notification.getTitle());
+    assertNull(notification.getBody());
+    assertEquals("myicon", notification.getIcon());
+    assertEquals("default", notification.getSound());
+    assertNull(notification.getBadge());
+    assertNull(notification.getTag());
+    assertNull(notification.getColor());
+    assertNull(notification.getClickAction());
+    assertNull(notification.getBodyLocKey());
+    assertNull(notification.getBodyLocArgs());
+    assertNull(notification.getTitleLocKey());
+    assertNull(notification.getTitleLocArgs());
+    String toString = notification.toString();
+    assertFalse(toString.contains("title"));
+    assertFalse(toString.contains("body"));
+    assertTrue(toString.contains("icon=myicon"));
+    assertTrue(toString.contains("sound=default"));
+    assertFalse(toString.contains("badge"));
+    assertFalse(toString.contains("tag"));
+    assertFalse(toString.contains("color"));
+    assertFalse(toString.contains("clickAction"));
+    assertFalse(toString.contains("bodyLocKey"));
+    assertFalse(toString.contains("bodyLocArgs"));
+    assertFalse(toString.contains("titleLocKey"));
+    assertFalse(toString.contains("titleLocArgs"));
+  }
+
+  @Test
+  public void testOptionalParameters() {
+    Notification notification = new Notification.Builder("ico")
+            .title("Hi")
+            .body("Hello world!")
+            .sound("notDefault")
+            .badge(3)
+            .tag("tagged")
+            .color("#ffffff")
+            .clickAction("OPEN_ACTIVITY_1")
+            .bodyLocKey("GREETING_BODY_FORMAT")
+            .bodyLocArgs(Arrays.asList("first", "second"))
+            .titleLocKey("GREETING_TITLE_FORMAT")
+            .titleLocArgs(Arrays.asList("one", "two", "three"))
+            .build();
+    assertEquals("Hi", notification.getTitle());
+    assertEquals("Hello world!", notification.getBody());
+    assertEquals("ico", notification.getIcon());
+    assertEquals("notDefault", notification.getSound());
+    assertTrue(notification.getBadge() == 3);
+    assertEquals("tagged", notification.getTag());
+    assertEquals("#ffffff", notification.getColor());
+    assertEquals("OPEN_ACTIVITY_1", notification.getClickAction());
+    assertEquals("GREETING_BODY_FORMAT", notification.getBodyLocKey());
+    assertTrue(notification.getBodyLocArgs().contains("first"));
+    assertTrue(notification.getBodyLocArgs().contains("second"));
+    assertTrue(notification.getBodyLocArgs().size() == 2);
+    assertEquals("GREETING_TITLE_FORMAT", notification.getTitleLocKey());
+    assertTrue(notification.getTitleLocArgs().contains("one"));
+    assertTrue(notification.getTitleLocArgs().contains("two"));
+    assertTrue(notification.getTitleLocArgs().contains("three"));
+    assertTrue(notification.getTitleLocArgs().size() == 3);
+    String toString = notification.toString();
+    assertTrue(toString.contains("title=Hi"));
+    assertTrue(toString.contains("body=Hello world!"));
+    assertTrue(toString.contains("sound=notDefault"));
+    assertTrue(toString.contains("badge=3"));
+    assertTrue(toString.contains("tag=tagged"));
+    assertTrue(toString.contains("color=#ffffff"));
+    assertTrue(toString.contains("clickAction=OPEN_ACTIVITY_1"));
+    assertTrue(toString.contains("bodyLocKey=GREETING_BODY_FORMAT"));
+    assertTrue(toString.contains("bodyLocArgs=[first, second]"));
+    assertTrue(toString.contains("titleLocKey=GREETING_TITLE_FORMAT"));
+    assertTrue(toString.contains("titleLocArgs=[one, two, three]"));
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testBodyLocArgsDataIsImmutable() {
+    Notification.Builder builder = new Notification.Builder("myicon");
+    builder.bodyLocArgs(new ArrayList<String>());
+    Notification notification = builder.build();
+    notification.getBodyLocArgs().clear();
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testTitleLocArgsDataIsImmutable() {
+    Notification.Builder builder = new Notification.Builder("myicon");
+    builder.titleLocArgs(new ArrayList<String>());
+    Notification notification = builder.build();
+    notification.getTitleLocArgs().clear();
+  }
+}


### PR DESCRIPTION
[GCM Connection Server Reference](https://developers.google.com/cloud-messaging/server-ref#notification-payload-support) describes notification part of send request which is currently not supported by rest-client implementation.

In order to add this feature I also had to switch non-multicast message body format from plain text to JSON since only it supports notification part.
