### PR TITLE
Added a connection and read timeout to Sender

### DIFF
--- a/client-libraries/java/rest-client/src/com/google/android/gcm/server/Sender.java
+++ b/client-libraries/java/rest-client/src/com/google/android/gcm/server/Sender.java
@@ -82,7 +82,9 @@ public class Sender {
       Logger.getLogger(Sender.class.getName());
 
   private final String key;
-
+  private int connectTimeout;
+  private int readTimeout;
+  
   /**
    * Default constructor.
    *
@@ -90,6 +92,34 @@ public class Sender {
    */
   public Sender(String key) {
     this.key = nonNull(key);
+  }
+  
+  /**
+   * Set the underlying URLConnection's connect timeout (in milliseconds). A timeout value of 0 specifies an infinite timeout.
+   * <p>
+   * Default is the system's default timeout.
+   *
+   * @see java.net.URLConnection#setConnectTimeout(int)
+   */
+  public final void setConnectTimeout(int connectTimeout) {
+      if (connectTimeout < 0) {
+          throw new IllegalArgumentException("timeout can not be negative");
+      }
+      this.connectTimeout = connectTimeout;
+  }
+
+  /**
+   * Set the underlying URLConnection's read timeout (in milliseconds). A timeout value of 0 specifies an infinite timeout.
+   * <p>
+   * Default is the system's default timeout.
+   *
+   * @see java.net.URLConnection#setReadTimeout(int)
+   */
+  public final void setReadTimeout(int readTimeout) {
+      if (readTimeout < 0) {
+          throw new IllegalArgumentException("timeout can not be negative");
+      }
+      this.readTimeout = readTimeout;
   }
 
   /**
@@ -617,6 +647,8 @@ public class Sender {
    */
   protected HttpURLConnection getConnection(String url) throws IOException {
     HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
+    conn.setConnectTimeout(connectTimeout);
+    conn.setReadTimeout(readTimeout);
     return conn;
   }
 


### PR DESCRIPTION
Sender doesn't currently expose any way to set timeouts.  This causes problems when the service is unavailable or unreachable.  These timeout values are used on the underlying HttpURLConnection to prevent problems with infinite timeouts.
