### PR TITLE
Use UTF-8 encoding for multi-messages

### DIFF
--- a/client-libraries/java/rest-client/src/com/google/android/gcm/server/Sender.java
+++ b/client-libraries/java/rest-client/src/com/google/android/gcm/server/Sender.java
@@ -561,7 +561,7 @@ public class Sender {
     }
     logger.fine("Sending POST to " + url);
     logger.finest("POST body: " + body);
-    byte[] bytes = body.getBytes();
+    byte[] bytes = body.getBytes(UTF8);
     HttpURLConnection conn = getConnection(url);
     conn.setDoOutput(true);
     conn.setUseCaches(false);

--- a/client-libraries/java/rest-client/test/com/google/android/gcm/server/SenderTest.java
+++ b/client-libraries/java/rest-client/test/com/google/android/gcm/server/SenderTest.java
@@ -732,14 +732,14 @@ public class SenderTest {
 
   @Test
   public void testPost() throws Exception {
-    String requestBody = "req";
+    String requestBody = "マルチバイト文字";
     String responseBody = "resp";
     setResponseExpectations(200, responseBody);
     HttpURLConnection response =
         sender.post(Constants.GCM_SEND_ENDPOINT, requestBody);
     assertEquals(requestBody, new String(outputStream.toByteArray()));
     verify(mockedConn).setRequestMethod("POST");
-    verify(mockedConn).setFixedLengthStreamingMode(requestBody.length());
+    verify(mockedConn).setFixedLengthStreamingMode(requestBody.getBytes("UTF-8").length);
     verify(mockedConn).setRequestProperty("Content-Type",
         "application/x-www-form-urlencoded;charset=UTF-8");
     verify(mockedConn).setRequestProperty("Authorization", "key=" + authKey);
@@ -748,14 +748,14 @@ public class SenderTest {
 
   @Test
   public void testPost_customType() throws Exception {
-    String requestBody = "req";
+    String requestBody = "マルチバイト文字";
     String responseBody = "resp";
     setResponseExpectations(200, responseBody);
     HttpURLConnection response =
         sender.post(Constants.GCM_SEND_ENDPOINT, "stuff", requestBody);
     assertEquals(requestBody, new String(outputStream.toByteArray()));
     verify(mockedConn).setRequestMethod("POST");
-    verify(mockedConn).setFixedLengthStreamingMode(requestBody.length());
+    verify(mockedConn).setFixedLengthStreamingMode(requestBody.getBytes("UTF-8").length);
     verify(mockedConn).setRequestProperty("Content-Type", "stuff");
     verify(mockedConn).setRequestProperty("Authorization", "key=" + authKey);
     assertEquals(200, response.getResponseCode());


### PR DESCRIPTION
The code for single messaging did encode the data with UTF-8 while the
multi-messaging did use the platform encoding. This causes problems on
non UTF-8 systems like Google AppEngine.

Now UTF-8 encoding is also used for multi messages.

Closes-Bug: 16, 17, 22, 28
