### PR TITLE
Add Maven pom files.

### DIFF
--- a/client-libraries/java/rest-client/.gitignore
+++ b/client-libraries/java/rest-client/.gitignore
@@ -1,3 +1,4 @@
 bin
 .classpath
 .project
+target

--- a/client-libraries/java/rest-client/pom.xml
+++ b/client-libraries/java/rest-client/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>gcm-rest-client</artifactId>
+	<name>Google Cloud Messaging (GCM) REST Client</name>
+	<description>REST Client for Google Cloud Messaging (GCM).</description>
+	<parent>
+		<groupId>com.google.android</groupId>
+		<artifactId>gcm</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+		<relativePath>../../../pom.xml</relativePath>
+	</parent>
+	<dependencies>
+		<dependency>
+			<groupId>com.googlecode.json-simple</groupId>
+			<artifactId>json-simple</artifactId>
+			<version>1.1.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-all</artifactId>
+			<version>1.8.5</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.12</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+	<build>
+		<sourceDirectory>src</sourceDirectory>
+		<testSourceDirectory>test</testSourceDirectory>
+	</build>
+</project>

--- a/client-libraries/java/rest-client/pom.xml
+++ b/client-libraries/java/rest-client/pom.xml
@@ -7,7 +7,7 @@
 	<name>Google Cloud Messaging (GCM) REST Client</name>
 	<description>REST Client for Google Cloud Messaging (GCM).</description>
 	<parent>
-		<groupId>com.google.android</groupId>
+		<groupId>com.google.cloud.messaging</groupId>
 		<artifactId>gcm</artifactId>
 		<version>1.0.0-SNAPSHOT</version>
 		<relativePath>../../../pom.xml</relativePath>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,63 @@
+<!--
+  - Copyright 2012 Google Inc.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  - use this file except in compliance with the License. You may obtain a copy
+  - of the License at
+  -
+  - http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  - WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  - License for the specific language governing permissions and limitations
+  - under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.google.android</groupId>
+	<artifactId>gcm</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>pom</packaging>
+	<parent>
+		<groupId>org.sonatype.oss</groupId>
+		<artifactId>oss-parent</artifactId>
+		<version>7</version>
+	</parent>
+	<name>Google Cloud Messaging (GCM)</name>
+	<description>Google Cloud Messaging (GCM) is a service that lets developers send data from servers to users' devices, and receive messages from devices on the same connection. This project contains client libraries and samples to help developers interface with and explore the Google Cloud Messaging APIs.</description>
+	<url>https://github.com/google/gcm</url>
+	<licenses>
+		<license>
+			<name>Apache 2.0</name>
+			<url>http://www.apache.org/licenses/LICENSE-2.0</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
+	<scm>
+		<url>https://github.com/google/gcm</url>
+		<connection>scm:git:git://github.com/google/gcm.git</connection>
+		<developerConnection>scm:git:git@github.com:google/gcm.git</developerConnection>
+	</scm>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+	<modules>
+		<module>client-libraries/java/rest-client</module>
+	</modules>
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>2.3.2</version>
+					<configuration>
+						<source>1.5</source>
+						<target>1.5</target>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.google.android</groupId>
+	<groupId>com.google.cloud.messaging</groupId>
 	<artifactId>gcm</artifactId>
 	<version>1.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>


### PR DESCRIPTION
I'd like to use gcm-rest-client in a Maven project so I've added pom.xml files.

I've used `com.google.cloud.messaging` as `groupId` and `gcm`/`gcm-rest-client` as `artifactId`s, hope it works for you. Please feel free to change these values (as well as version).

CLA is signed (highsource).
