### PR TITLE
Added a connection and read timeout to Sender

### DIFF
--- a/client-libraries/java/rest-client/src/com/google/android/gcm/server/Sender.java
+++ b/client-libraries/java/rest-client/src/com/google/android/gcm/server/Sender.java
@@ -91,7 +91,9 @@ public class Sender {
       Logger.getLogger(Sender.class.getName());
 
   private final String key;
-
+  private int connectTimeout;
+  private int readTimeout;
+  
   /**
    * Default constructor.
    *
@@ -101,6 +103,34 @@ public class Sender {
     this.key = nonNull(key);
   }
 
+  /**
+   * Set the underlying URLConnection's connect timeout (in milliseconds). A timeout value of 0 specifies an infinite timeout.
+   * <p>
+   * Default is the system's default timeout.
+   *
+   * @see java.net.URLConnection#setConnectTimeout(int)
+   */
+  public final void setConnectTimeout(int connectTimeout) {
+      if (connectTimeout < 0) {
+          throw new IllegalArgumentException("timeout can not be negative");
+      }
+      this.connectTimeout = connectTimeout;
+  }
+
+  /**
+   * Set the underlying URLConnection's read timeout (in milliseconds). A timeout value of 0 specifies an infinite timeout.
+   * <p>
+   * Default is the system's default timeout.
+   *
+   * @see java.net.URLConnection#setReadTimeout(int)
+   */
+  public final void setReadTimeout(int readTimeout) {
+      if (readTimeout < 0) {
+          throw new IllegalArgumentException("timeout can not be negative");
+      }
+      this.readTimeout = readTimeout;
+  } 
+  
   /**
    * Sends a message to one device, retrying in case of unavailability.
    *
@@ -623,7 +653,10 @@ public class Sender {
    * Gets an {@link HttpURLConnection} given an URL.
    */
   protected HttpURLConnection getConnection(String url) throws IOException {
-    return (HttpURLConnection) new URL(url).openConnection();
+    HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
+    conn.setConnectTimeout(connectTimeout);
+    conn.setReadTimeout(readTimeout);
+    return conn;
   }
 
   /**

--- a/client-libraries/java/rest-client/test/com/google/android/gcm/server/SenderTest.java
+++ b/client-libraries/java/rest-client/test/com/google/android/gcm/server/SenderTest.java
@@ -105,6 +105,36 @@ public class SenderTest {
     new Sender(null);
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void testSetConnectTimeout_lessThanZero() {
+    sender.setConnectTimeout(-1);
+  }
+
+  @Test
+  public void testSetConnectTimeout() throws IOException {
+    int connectTimeout = 5000;
+    sender.setConnectTimeout(connectTimeout);
+    
+    // does not establish the actual network connection on creation see java.util.URL#openConnection
+    HttpURLConnection connection = sender.getConnection("http://www.google.com");
+    assertEquals(connectTimeout, connection.getConnectTimeout());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testSetReadTimeout_lessThanZero() {
+    sender.setReadTimeout(-1);
+  }
+  
+  @Test
+  public void testSetReadTimeout() throws IOException {
+    int readTimeout = 5000;
+    sender.setReadTimeout(readTimeout);
+    
+    // does not establish the actual network connection on creation see java.util.URL#openConnection
+    HttpURLConnection connection = sender.getConnection("http://www.google.com");
+    assertEquals(readTimeout, connection.getReadTimeout());
+  }  
+
   @Test
   public void testSend_noRetryOk() throws Exception {
     doNotSleep();


### PR DESCRIPTION
Current the connection does not all timeouts to be set by the user.  I've closed pull request #81 which was committed under the wrong user and issued this one instead.  This should have a valid user which has signed the CLA.
