### PR TITLE
Add support for content_available field for Java

### DIFF
--- a/client-libraries/java/rest-client/src/com/google/android/gcm/server/Constants.java
+++ b/client-libraries/java/rest-client/src/com/google/android/gcm/server/Constants.java
@@ -78,6 +78,11 @@ public final class Constants {
   public static final String PARAM_PRIORITY = "priority";
 
   /**
+   * Parameter used to set the content available (iOS only)
+   */
+  public static final String PARAM_CONTENT_AVAILABLE = "content_available";
+
+  /**
    * Value used to set message priority to normal.
    */
   public static final String MESSAGE_PRIORITY_NORMAL = "normal";

--- a/client-libraries/java/rest-client/src/com/google/android/gcm/server/Message.java
+++ b/client-libraries/java/rest-client/src/com/google/android/gcm/server/Message.java
@@ -66,7 +66,9 @@ public final class Message implements Serializable {
   private final Boolean dryRun;
   private final String restrictedPackageName;
   private final String priority;
+  private final Boolean contentAvailable;
   private final Notification notification;
+
 
   public enum Priority {
     NORMAL, HIGH
@@ -83,6 +85,7 @@ public final class Message implements Serializable {
     private Boolean dryRun;
     private String restrictedPackageName;
     private String priority;
+    private Boolean contentAvailable;
     private Notification notification;
 
     public Builder() {
@@ -160,6 +163,14 @@ public final class Message implements Serializable {
       return this;
     }
 
+    /**
+     * Sets the contentAvailable property
+     */
+    public Builder contentAvailable(Boolean value){
+        contentAvailable = value;
+        return this;
+    }
+
     public Message build() {
       return new Message(this);
     }
@@ -174,6 +185,7 @@ public final class Message implements Serializable {
     dryRun = builder.dryRun;
     restrictedPackageName = builder.restrictedPackageName;
     priority = builder.priority;
+    contentAvailable = builder.contentAvailable;
     notification = builder.notification;
   }
 
@@ -220,6 +232,13 @@ public final class Message implements Serializable {
   }
 
   /**
+   * Gets the contentAvailable value
+   */
+  public Boolean getContentAvailable() {
+      return contentAvailable;
+  }
+
+  /**
    * Gets the payload data, which is immutable.
    */
   public Map<String, String> getData() {
@@ -238,6 +257,9 @@ public final class Message implements Serializable {
     StringBuilder builder = new StringBuilder("Message(");
     if (priority != null) {
       builder.append("priority=").append(priority).append(", ");
+    }
+    if (contentAvailable != null){
+        builder.append("contentAvailable=").append(contentAvailable).append(", ");
     }
     if (collapseKey != null) {
       builder.append("collapseKey=").append(collapseKey).append(", ");

--- a/client-libraries/java/rest-client/src/com/google/android/gcm/server/Sender.java
+++ b/client-libraries/java/rest-client/src/com/google/android/gcm/server/Sender.java
@@ -43,6 +43,7 @@ import static com.google.android.gcm.server.Constants.PARAM_COLLAPSE_KEY;
 import static com.google.android.gcm.server.Constants.PARAM_DELAY_WHILE_IDLE;
 import static com.google.android.gcm.server.Constants.PARAM_DRY_RUN;
 import static com.google.android.gcm.server.Constants.PARAM_PRIORITY;
+import static com.google.android.gcm.server.Constants.PARAM_CONTENT_AVAILABLE;
 import static com.google.android.gcm.server.Constants.PARAM_RESTRICTED_PACKAGE_NAME;
 import static com.google.android.gcm.server.Constants.PARAM_TIME_TO_LIVE;
 import static com.google.android.gcm.server.Constants.TOKEN_CANONICAL_REG_ID;
@@ -456,6 +457,7 @@ public class Sender {
       return;
     }
     setJsonField(mapRequest, PARAM_PRIORITY, message.getPriority());
+    setJsonField(mapRequest, PARAM_CONTENT_AVAILABLE, message.getContentAvailable());
     setJsonField(mapRequest, PARAM_TIME_TO_LIVE, message.getTimeToLive());
     setJsonField(mapRequest, PARAM_COLLAPSE_KEY, message.getCollapseKey());
     setJsonField(mapRequest, PARAM_RESTRICTED_PACKAGE_NAME, message.getRestrictedPackageName());

--- a/client-libraries/java/rest-client/test/com/google/android/gcm/server/MessageTest.java
+++ b/client-libraries/java/rest-client/test/com/google/android/gcm/server/MessageTest.java
@@ -48,6 +48,7 @@ public class MessageTest {
   public void testOptionalParameters() {
     Message message = new Message.Builder()
         .priority(Message.Priority.HIGH)
+        .contentAvailable(true)
         .collapseKey("108")
         .delayWhileIdle(true)
         .timeToLive(42)
@@ -59,6 +60,7 @@ public class MessageTest {
         .notification(new Notification.Builder("my").build())
         .build();
     assertEquals("high", message.getPriority());
+    assertTrue(message.getContentAvailable());
     assertEquals("108", message.getCollapseKey());
     assertTrue(message.isDelayWhileIdle());
     assertEquals(42, message.getTimeToLive().intValue());
@@ -70,6 +72,7 @@ public class MessageTest {
     assertEquals("v2", data.get("k2"));
     String toString = message.toString();
     assertTrue(toString.contains("priority=high"));
+    assertTrue(toString.contains("contentAvailable=true"));
     assertTrue(toString.contains("collapseKey=108"));
     assertTrue(toString.contains("timeToLive=42"));
     assertTrue(toString.contains("delayWhileIdle=true"));


### PR DESCRIPTION
Fixes #162.  According to GCM reference,  on iOS, use this field to represent content-available in the APNS payload. When a notification or message is sent and this is set to true, an inactive client app is awoken. On Android, data messages wake the app by default. On Chrome, currently not supported.
