### PR TITLE
Added a constructor that passes the endpoint

### DIFF
--- a/client-libraries/java/rest-client/src/com/google/android/gcm/server/Sender.java
+++ b/client-libraries/java/rest-client/src/com/google/android/gcm/server/Sender.java
@@ -92,6 +92,7 @@ public class Sender {
       Logger.getLogger(Sender.class.getName());
 
   private final String key;
+  private final String endpoint;
 
   /**
    * Default constructor.
@@ -100,6 +101,18 @@ public class Sender {
    */
   public Sender(String key) {
     this.key = nonNull(key);
+    this.endpoint = GCM_SEND_ENDPOINT;
+  }
+
+  /**
+   * Additional constructor that passes the endpoint as well. Can be used for testing with a mock.
+   *
+   * @param key API key obtained through the Google API Console.
+   * @param endpoint An endpoint that can accept notification requests. Normally the GCM Endpoint.
+   */
+  public Sender(String key, String endpoint) {
+    this.key = nonNull(key);
+    this.endpoint = nonNull(endpoint);
   }
 
   /**
@@ -417,7 +430,7 @@ public class Sender {
     HttpURLConnection conn;
     int status;
     try {
-      conn = post(GCM_SEND_ENDPOINT, "application/json", requestBody);
+      conn = post(endpoint, "application/json", requestBody);
       status = conn.getResponseCode();
     } catch (IOException e) {
       logger.log(Level.FINE, "IOException posting to GCM", e);
@@ -618,7 +631,7 @@ public class Sender {
   protected static void addParameter(StringBuilder body, String name,
       String value) {
     nonNull(body).append('&')
-        .append(nonNull(name)).append('=').append(nonNull(value));
+            .append(nonNull(name)).append('=').append(nonNull(value));
   }
 
   /**


### PR DESCRIPTION
We need the flexibility to have a constructor that passes the endpoint to allow testing against a mock. The default original constructor applies the default GCM endpoint. The additional one allows to pass an endpoint of your choice.
